### PR TITLE
feat: allow preview service api key override

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 [[package]]
 name = "dylibso-observe-sdk"
 version = "0.1.0"
-source = "git+https://github.com/dylibso/observe-sdk.git?branch=main#5f7af32db65faf338a6a379480f514017cb42868"
+source = "git+https://github.com/dylibso/observe-sdk.git#5f7af32db65faf338a6a379480f514017cb42868"
 dependencies = [
  "anyhow",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 [[package]]
 name = "dylibso-observe-sdk"
 version = "0.1.0"
-source = "git+https://github.com/dylibso/observe-sdk.git?branch=main#0c8edcda62d4f7b07dd270ae37b0b556208d956c"
+source = "git+https://github.com/dylibso/observe-sdk.git?branch=main#5f7af32db65faf338a6a379480f514017cb42868"
 dependencies = [
  "anyhow",
  "log",
@@ -1275,10 +1275,11 @@ dependencies = [
 [[package]]
 name = "modsurfer-demangle"
 version = "0.1.0"
-source = "git+https://github.com/dylibso/modsurfer#d6807f347dd64a83ddc5a3173f160a5553328a45"
+source = "git+https://github.com/dylibso/modsurfer#574f16bebfc5449394d7dc082b9acb7c4a59b186"
 dependencies = [
  "cpp_demangle 0.4.1",
  "rustc-demangle",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2220,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.85"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6cb788c4e39112fbe1822277ef6fb3c55cd86b95cb3d3c4c1c9597e4ac74b4"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2230,9 +2231,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.85"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e522ed4105a9d626d885b35d62501b30d9666283a5c8be12c14a8bdafe7822"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
@@ -2245,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.85"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "358a79a0cb89d21db8120cbfb91392335913e4890665b1a7981d9e956903b434"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2255,9 +2256,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.85"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4783ce29f09b9d93134d41297aded3a712b7b979e9c6f28c32cb88c973a94869"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2268,9 +2269,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.85"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a901d592cafaa4d711bc324edfaff879ac700b19c3dfd60058d2b445be2691eb"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-encoder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ colored = "2.0"
 serde = "1.0"
 rust-embed = "6.6.1"
 is-terminal = "0.4.7"
-dylibso-observe-sdk = { git = "https://github.com/dylibso/observe-sdk.git", branch = "main" }
+dylibso-observe-sdk = { git = "https://github.com/dylibso/observe-sdk.git", commit = "5f7af32db65faf338a6a379480f514017cb42868" }
 tokio = "1.28.2"
 ureq = "2"
 ureq_multipart = "1.1.1"

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ function-runner -f example/discount.wasm -j example/discount.json
 
 *Note*: This demo auto-instruments the code for you with a trial API key, but this section describes how the service works
 
+### Using your own API key
+
+Contact support@dylibso.com and use your own API key via:
+```bash
+export DYLIBSO_OBSERVE_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxx
+function-runner -f example/discount.wasm -j example/discount.json
+```
+
 You can now instrument your Shopify function with our instrumenter. The only way to instrument your Wasm right now is through the instrumentation service. The easiest way to do this is to send up your Wasm with curl and get an instrumented Wasm module back:
 
 ```bash

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -53,12 +53,16 @@ pub async fn run(function_path: PathBuf, input: Vec<u8>) -> Result<FunctionRunRe
         .add_file("wasm", &function_path)?
         .finish()?;
 
-    println!("The wasm code instrumentation is currently in preview, and the API key used in this demo will expire on Sept. 1 2023. Contact support@dylibso.com for your own key.");
+    let token = std::env::var("DYLIBSO_OBSERVE_API_KEY")
+        .unwrap_or_else(|_| {
+            println!("The wasm code instrumentation is currently in preview, and the API key used in this demo will expire on Sept. 1 2023. Contact support@dylibso.com for your own key.");
+            return "48268d3d35a90f8ddfd47ea520a7dba9".to_string();
+        });
     println!("Instrumenting the module first...");
     let resp = ureq::post("https://compiler-preview.dylibso.com/instrument")
         // this key is a public, limited trial API key for this demo. please reach out to us for
         // your own key
-        .set("Authorization", "Bearer 48268d3d35a90f8ddfd47ea520a7dba9")
+        .set("Authorization", &format!("Bearer {}", token))
         .set("Content-Type", &content_type)
         .send_bytes(&data)?;
 


### PR DESCRIPTION
Updates SDK and enables use of provided compiler preview API key.

```sh
export DYLIBSO_OBSERVE_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxx
function-runner -f example/discount.wasm -j example/discount.json
```